### PR TITLE
Fixed Status Monitor Overlay issue

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -398,15 +398,11 @@
         },
         "statusmonitoroverlay": {
             "repo": "masagrator/Status-Monitor-Overlay",
-            "regex": [".*Status-Monitor-Overlay.*\\.ovl"],
+            "regex": [".*Status-Monitor-Overlay.*\\.zip"],
             "steps": [
                 {
-                    "name": "create_dir",
-                    "arguments": ["switch/.overlays"]
-                },
-                {
-                    "name": "move",
-                    "arguments": ["Status-Monitor-Overlay.ovl", "switch/.overlays/Status-Monitor-Overlay.ovl"]
+                    "name": "extract",
+                    "arguments": [".*Status-Monitor-Overlay.*\\.zip"]
                 }
             ]
         },


### PR DESCRIPTION
Current master branch encounters a file not found error with Status Monitor Overlay module due to the release assets being changed to a zip archive in [Release 1.0.0](https://github.com/masagrator/Status-Monitor-Overlay/releases/tag/1.0.0). 

The fix is to update the regex and change to an extract step in settings.json. The zip archive already contains the switch/.overlays folder, so create_dir is no longer necessary.