### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/buildDev.yml
+++ b/.github/workflows/buildDev.yml
@@ -12,32 +12,32 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-      
+    - uses: actions/checkout@v4
+
     - id: set-version
       run: |
         version=$(python -c 'import sys, json; f=open("./settings.json");print(json.loads(f.read())["releaseVersion"])')
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Set up hub
       run: |
         sudo apt install hub -y
-        
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
     - name: Install dependencies
       run: |
         if [ -f ../requirements.txt ]; then pip3 install -r ../requirements.txt; fi
-        
+
     - name: Create DeepSea Packages
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: | 
+      run: |
         python ./start.py -gt="$GITHUB_TOKEN"
 
     - name: Create DevRelease

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -12,34 +12,34 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-      
+    - uses: actions/checkout@v4
+
     - id: set-version
       run: |
         version=$(python -c 'import sys, json; f=open("./settings.json");print(json.loads(f.read())["releaseVersion"])')
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Set up hub
       run: |
         sudo apt install hub -y
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
     - name: Install dependencies
       run: |
         if [ -f ../requirements.txt ]; then pip3 install -r ../requirements.txt; fi
-        
+
     - name: Create DeepSea Packages
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: | 
+      run: |
         python ./start.py -gt="$GITHUB_TOKEN"
-        
+
     - name: Create Release
       run: |
         set -x


### PR DESCRIPTION
Hi!

This is just a bit of maintenance for the two GitHub Actions workflows.

- Update action's versions
- Replace deprecated `::set-output` with `>> $GITHUB_OUTPUT`.
  See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/