### PR TITLE
sys-ftpd-light is now sys-ftpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Send the Hekate payload to your Switch in RCM mode and launch the CFW
 | [Status Monitor Overlay](https://github.com/masagrator/Status-Monitor-Overlay) | ✅ |  |
 | [sys-clk](https://github.com/retronx-team/sys-clk) | ✅ |  |
 | [sys-con](https://github.com/cathery/sys-con) | ✅ |  |  |
-| [sys-ftpd-light](https://github.com/cathery/sys-ftpd-light) | ✅ | ✅ |  |
+| [sys-ftpd](https://github.com/cathery/sys-ftpd) | ✅ | ✅ |  |
 | [TegraExplorer](https://github.com/joel16/NX-Shell) | ✅ |  |  |
 | [Tesla-Menu](https://github.com/WerWolv/Tesla-Menu) | ✅ | ✅ |  |
 | [Goldleaf](https://github.com/XorTroll/Goldleaf) | ✅ | ✅ |  |

--- a/src/settings.json
+++ b/src/settings.json
@@ -26,7 +26,7 @@
                 "emuiibo",
                 "jksv",
                 "goldleaf",
-                "sysftpdlight",
+                "sysftpd",
                 "nxovlloader",
                 "ovlsysmodules",
                 "teslamenu",
@@ -50,7 +50,7 @@
                 "goldleaf",
                 "sysclk",
                 "syscon",
-                "sysftpdlight",
+                "sysftpd",
                 "nxovlloader",
                 "ovlsysmodules",
                 "teslamenu",
@@ -314,13 +314,13 @@
                 }
             ]
         },
-        "sysftpdlight": {
+        "sysftpd": {
             "repo": "cathery/sys-ftpd",
-            "regex": [".*sys-ftpd-light.*\\.zip"],
+            "regex": [".*sys-ftpd.*\\.zip"],
             "steps": [
                 {
                     "name": "extract",
-                    "arguments": [".*sys-ftpd-light.*\\.zip"]
+                    "arguments": [".*sys-ftpd.*\\.zip"]
                 },
                 {
                     "name": "delete",


### PR DESCRIPTION
Hi!

The repo and now its assets have been renamed from `sys-ftpd-light` to `sys-ftpd`.